### PR TITLE
Update PDFThumbService.php

### DIFF
--- a/src/services/PDFThumbService.php
+++ b/src/services/PDFThumbService.php
@@ -118,7 +118,7 @@ class PDFThumbService extends Component
           $this->asset->size, $this->asset->id, $this->asset->dateModified->format('Y-m-d H:i:s'),
           $this->dimensions(), $this->filetype, $this->force_canvas_size
         );
-        return md5(join($parts,'-'));
+        return md5(join('-',$parts)); //php 7.4 fix  
       }
       private function slashify($string) {
         $string = trim($string, '/');


### PR DESCRIPTION
php 7.4 fix -  join(): Passing glue string after array is deprecated. Swap the parameters